### PR TITLE
fix(launch): Format launch date to launch site timezone

### DIFF
--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -19,10 +19,11 @@ import {
   Stack,
   AspectRatioBox,
   StatGroup,
+  Tooltip,
 } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
-import { formatDateTime } from "../utils/format-date";
+import { formatDateTime, formatLocalDateTime } from "../utils/format-date";
 import Error from "./error";
 import Breadcrumbs from "./breadcrumbs";
 
@@ -124,7 +125,16 @@ function TimeAndLocation({ launch }) {
           </Box>
         </StatLabel>
         <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.launch_date_local)}
+          <Tooltip
+            label={`Your time: ${formatDateTime(launch.launch_date_local)}`}
+            fontSize="md"
+            placement="top"
+          >
+            {formatLocalDateTime(
+              launch.launch_date_local,
+              launch.launch_date_utc
+            )}
+          </Tooltip>
         </StatNumber>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>
       </Stat>

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -130,10 +130,7 @@ function TimeAndLocation({ launch }) {
             fontSize="md"
             placement="top"
           >
-            {formatLocalDateTime(
-              launch.launch_date_local,
-              launch.launch_date_utc
-            )}
+            {formatLocalDateTime(launch.launch_date_local)}
           </Tooltip>
         </StatNumber>
         <StatHelpText>{timeAgo(launch.launch_date_utc)}</StatHelpText>

--- a/src/utils/__tests__/format-date.test.js
+++ b/src/utils/__tests__/format-date.test.js
@@ -1,0 +1,14 @@
+import { formatLocalDateTime } from "../format-date";
+
+
+describe('formatLocalDateTime', () => {
+    it('should return UTC timezone', () => {
+      const result = formatLocalDateTime("2020-11-21T09:17:00.000Z")
+      expect(result).toBe("November 21, 2020, 9:17:00 AM UTC")
+    })
+
+    it('should return GMT-8 timezone', () => {
+      const result = formatLocalDateTime("2020-11-21T09:17:00-08:00")
+      expect(result).toBe("November 21, 2020, 9:17:00 AM GMT-8")
+    })
+})

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -18,3 +18,59 @@ export function formatDateTime(timestamp) {
     timeZoneName: "short",
   }).format(new Date(timestamp));
 }
+
+const timeZones = {
+  "-12:00": "Etc/GMT+12",
+  "-11:00": "Etc/GMT+11",
+  "-10:00": "Etc/GMT+10",
+  "-09:00": "Etc/GMT+9",
+  "-08:00": "Etc/GMT+8",
+  "-07:00": "Etc/GMT+7",
+  "-06:00": "Etc/GMT+6",
+  "-05:00": "Etc/GMT+5",
+  "-04:00": "Etc/GMT+4",
+  "-03:00": "Etc/GMT+3",
+  "-02:00": "Etc/GMT+2",
+  "-01:00": "Etc/GMT+1",
+  "-00:00": "Etc/GMT",
+  "+00:00": "Etc/GMT",
+  "+01:00": "Etc/GMT-1",
+  "+02:00": "Etc/GMT-2",
+  "+03:00": "Etc/GMT-3",
+  "+04:00": "Etc/GMT-4",
+  "+05:00": "Etc/GMT-5",
+  "+06:00": "Etc/GMT-6",
+  "+07:00": "Etc/GMT-7",
+  "+08:00": "Etc/GMT-8",
+  "+09:00": "Etc/GMT-9",
+  "+10:00": "Etc/GMT-10",
+  "+11:00": "Etc/GMT-11",
+  "+12:00": "Etc/GMT-12",
+};
+/**
+ * This could be replaced with google timezone api since we have access to launch site long / lat 
+ * {@link https://developers.google.com/maps/documentation/timezone/get-started#json developers.google.com}.
+ */
+
+export function formatLocalDateTime(timestampLocal, timestampUTC) {
+  const regex = new RegExp("Z");
+  const dateLocal = new Date(timestampLocal);
+  let zone = "UTC";
+
+  if (!regex.test(timestampLocal)) {
+    const offset = timestampLocal.substring(timestampLocal.length - 6);
+
+    zone = timeZones[offset];
+  }
+
+  return dateLocal.toLocaleString("en-US", {
+    timeZone: zone,
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+    second: "numeric",
+    timeZoneName: "short",
+  });
+}

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -52,11 +52,11 @@ const timeZones = {
  * {@link https://developers.google.com/maps/documentation/timezone/get-started#json developers.google.com}.
  */
 
-export function formatLocalDateTime(timestampLocal, timestampUTC) {
+export function formatLocalDateTime(timestampLocal) {
   const regex = new RegExp("Z");
   const dateLocal = new Date(timestampLocal);
   let zone = "UTC";
-
+  // To check if the local timestamp has a timezone
   if (!regex.test(timestampLocal)) {
     const offset = timestampLocal.substring(timestampLocal.length - 6);
 


### PR DESCRIPTION
## The challenge 🍿

The team discovered that the launch datetime on the launch details page (e.g. /launches/92) is displayed in the timezone of the app's user. However, the intent was to show it in the local timezone of the launch site instead

## The solution 💯

By extracting the timezone from `launch_date_local` we can use that in the options for `Date.toLocaleString`

The time for the user timezone is still accessible with a `Tooltip` on the timestamp

## Thoughts 🤔 

A better solution in the future could be to make use of a third party API like [googlemaps timezone](https://developers.google.com/maps/documentation/timezone/get-started) to get the exact time zone abbreviation for both standard time and daylight saving time.   

## Evidence 📸 

<img width="472" alt="image" src="https://user-images.githubusercontent.com/11654513/161611823-f81bb3a0-fb44-44c1-9022-2a57c34d7fb5.png">
